### PR TITLE
govulncheck-action: support go-version-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ use the following syntax:
      go-package: <your-package-pattern>
 ```
 
+To use `go.mod` or `go.work` to specify the version, use the following syntax ([further reading](https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file)):
+```yaml
+- id: govulncheck
+  uses: golang/govulncheck-action@v1
+  with:
+     go-version-file: <your-go-mod-or-work> # 'go.mod' or 'go.work'
+     go-package: <your-package-pattern>
+```
+
 For example, the code snippet below can be used to run govulncheck against a
 repository on every push:
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: 'Version of Go to use for govulncheck'
     required: false
     default: '>=1.19.0'
+  go-version-file:  # look at a go version file to user for govulncheck
+    description: 'Path to the go.mod or go.work file.' # see: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file
+    required: false
   check-latest:
     description: 'Set this option to true if you want the action to always check for the latest available Go version that satisfies the version spec'
     required: false
@@ -24,6 +27,7 @@ runs:
     - uses: actions/setup-go@v4.0.0
       with:
         go-version: ${{ inputs.go-version-input }}
+        go-version-file: ${{ inputs.go-version-file }}
         check-latest: ${{ inputs.check-latest }}
         cache: ${{ inputs.cache }}
     - name: Install govulncheck


### PR DESCRIPTION
This change allows support for go-version-file in this action so that consumers can reference a `go.mod` or `go.work` file rather than keeping their action in sync with their go tooling. As actions/setup-go has go-version overwrite go-version-file, this will do the same. If both are provided, the go-version-input is used.

See: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file

Fixes golang/go#61343

To use the go version file, you can do the following (remember to checkout your code first):
```
- id: govulncheck
  uses: golang/govulncheck-action@v1
  with:
     go-version-file: 'go.mod'
     go-package: <your-package-pattern>
```