### PR TITLE
Support specifying govulncheck version as an input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
   go-version-file:
     description: 'Path to the go.mod or go.work file.'
     required: false
+  govulncheck-version:
+    description: 'Version of govulncheck to install'
+    required: true
+    default: 'latest'
 runs:
   using: "composite"
   steps:
@@ -39,7 +43,7 @@ runs:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.cache }}
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      run: go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.govulncheck-version }}
       shell: bash
     - name: Run govulncheck
       run: govulncheck -C ${{ inputs.work-dir }} ${{ inputs.go-package }}


### PR DESCRIPTION
The latest version of `govulncheck` (`v1.0.2`) switched to using `go list` which is causing us some issues with repositories that use `replace` directives (https://github.com/golang/go/issues/65124), so in those cases, being able to pin to a previous version until we can fix the issue would be useful.