### PR TITLE
action.yml: upgrade actions to checkout@v4, setup-go@v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
   using: "composite"
   steps:
     - if: inputs.repo-checkout != 'false' # only explicit false prevents repo checkout
-      uses: actions/checkout@v3
-    - uses: actions/setup-go@v4.0.0
+      uses: actions/checkout@v4
+    - uses: actions/setup-go@v5.0.0
       with:
         go-version: ${{ inputs.go-version-input }}
         check-latest: ${{ inputs.check-latest }}


### PR DESCRIPTION
The update is needed because `checkout@v3` https://github.com/actions/checkout/blob/v3/action.yml#L90 and `setup-go@v4.0.0` https://github.com/actions/setup-go/blob/v4.0.0/action.yml#L28 use Node 16 which is deprecated (see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).