### PR TITLE
Add input to specify go.sum location(s)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
   go-version-file:
     description: 'Path to the go.mod or go.work file.'
     required: false
+  cache-dependency-path:
+    description: 'Path(s) to the go.sum file(s).'
+    required: false
+    default: go.sum
 runs:
   using: "composite"
   steps:
@@ -38,6 +42,7 @@ runs:
         check-latest: ${{ inputs.check-latest }}
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash


### PR DESCRIPTION
This PR adds an input that allows the specification of a non-default go.mod location (or locations). Useful if you use a monorepo.