### PR TITLE
Use major version of official Github actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,8 @@ runs:
   using: "composite"
   steps:
     - if: inputs.repo-checkout != 'false' # only explicit false prevents repo checkout
-      uses: actions/checkout@v4.1.1
-    - uses: actions/setup-go@v5.0.0
+      uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version-input }}
         check-latest: ${{ inputs.check-latest }}


### PR DESCRIPTION
For simplicity, it might be easier keeping official GitHub Actions pinned to major versions only (like `@v5` instead of `@v5.0.0`). This way we automatically get minor and patch updates.

Here's an example of why: We use `golang/govulncheck-action` in our our GitHub Enterprise Server (GHES) environment. A recent release of the `actions/setup-go` action, [`v5.2.0`](https://github.com/actions/setup-go/releases/tag/v5.2.0) fixed a GHES specific issue, but since this action is pinned to the patch release which came out in December of 2023 we don't get these fixes.

Pinning to a specific patch version also forces our GitHub Action workflows that have other steps that use `setup-go@v5` to download two different versions of the same action in that single workflow.