### PR TITLE
action.yml: update dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,8 @@ runs:
   using: "composite"
   steps:
     - if: inputs.repo-checkout != 'false' # only explicit false prevents repo checkout
-      uses: actions/checkout@v4.2.2
-    - uses: actions/setup-go@v5.4.0
+      uses: actions/checkout@v6.0.2
+    - uses: actions/setup-go@v6.2.0
       with:
         go-version: ${{ inputs.go-version-input }}
         check-latest: ${{ inputs.check-latest }}


### PR DESCRIPTION
- actions/checkout: v4.2.2 -> v6.0.1
- actions/setup-go: v5.4.0 -> v6.1.0

See:
- https://github.com/actions/checkout/releases
- https://github.com/actions/setup-go/releases

Notable fixes:
- https://github.com/actions/setup-go/pull/665
