### PR TITLE
action.yml: unset GOOS/GOARCH when installing govulncheck

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,9 @@ runs:
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash
+      env:
+        GOOS: ''
+        GOARCH: ''
     - if: inputs.output-file == ''
       name: Run govulncheck
       run: govulncheck -C ${{ inputs.work-dir }} -format ${{ inputs.output-format }} ${{ inputs.go-package }}


### PR DESCRIPTION
When a caller sets GOOS=windows at the job level (e.g.
prometheus/windows_exporter, which builds for Windows but runs
CI on Linux), go install would build govulncheck for Windows
instead of the Linux runner, causing "command not found" on
execution.

Clearing GOOS and GOARCH in the install step ensures the tool
is always built for the host platform.