### PR TITLE
action.yml: update setup-go to the latest tagged version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - if: inputs.repo-checkout != 'false' # only explicit false prevents repo checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ inputs.go-version-input }}
         check-latest: ${{ inputs.check-latest }}


### PR DESCRIPTION
bump setup-go to latest tagged version in order to use go.dev instead golang.org as seemingly the latter sometimes lags behind with artifacts